### PR TITLE
Fix serde integration if Digest is not {Des,S}erialize

### DIFF
--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -2,13 +2,15 @@ use digest::Digest;
 use digest::Digestible;
 use digest::Hash;
 use proof::*;
-use std::collections::hash_map;
+
+use std::collections::{HashMap, hash_map};
 use std::iter;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone)]
 pub struct TreeHead<D: Digest> {
     count: u64,
+    #[cfg_attr(feature = "serde", serde(bound = ""))]
     hash: Hash<D>,
 }
 
@@ -25,7 +27,9 @@ impl<D: Digest> TreeHead<D> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone)]
 pub struct MerkleTree<D: Digest> {
-    pub(crate) map: hash_map::HashMap<Hash<D>, usize>,
+    #[cfg_attr(feature = "serde", serde(bound = ""))]
+    pub(crate) map: HashMap<Hash<D>, usize>,
+    #[cfg_attr(feature = "serde", serde(bound = ""))]
     pub(crate) tree: Vec<Hash<D>>,
 }
 
@@ -33,7 +37,7 @@ impl<D: Digest> MerkleTree<D> {
     pub fn new() -> MerkleTree<D> {
         let empty = D::default().fixed_result();
         let mut m = MerkleTree::<D> {
-            map: hash_map::HashMap::new(),
+            map: HashMap::new(),
             tree: Vec::new(),
         };
         m.tree.push(empty.clone());
@@ -157,6 +161,7 @@ impl<D: Digest> iter::Extend<Hash<D>> for MerkleTree<D> {
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct OwningMerkleTree<T: Digestible, D: Digest> {
+    #[cfg_attr(feature = "serde", serde(bound = ""))]
     mt: MerkleTree<D>,
     objs: Vec<T>,
 }

--- a/src/signed_merkle.rs
+++ b/src/signed_merkle.rs
@@ -16,6 +16,7 @@ use untrusted;
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone)]
 pub struct SignedTreeHead<D: Digest> {
+    #[cfg_attr(feature = "serde", serde(bound = ""))]
     th: TreeHead<D>,
     sig: Vec<u8>,
 }
@@ -48,8 +49,10 @@ impl<D: Digest> SignedTreeHead<D> {
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct SignedMerkleTree<D: Digest> {
+    #[cfg_attr(feature = "serde", serde(bound = ""))]
     mt: MerkleTree<D>,
     keypair: KeyPair,
+    #[cfg_attr(feature = "serde", serde(bound = ""))]
     sth: SignedTreeHead<D>,
 }
 
@@ -108,6 +111,7 @@ impl<D: Digest> iter::Extend<Hash<D>> for SignedMerkleTree<D> {
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct SignedOwningMerkleTree<T: Digestible, D: Digest> {
+    #[cfg_attr(feature = "serde", serde(bound = ""))]
     smt: SignedMerkleTree<D>,
     objs: Vec<T>,
 }

--- a/tests/large_tree.rs
+++ b/tests/large_tree.rs
@@ -118,9 +118,8 @@ fn large_tree() {
     let opubk = okp.pub_key();
     let mut bulkmt =
         MerkleTree::<sha2::Sha256>::from_iter(hashes.iter().cloned());
-    let mut bulkomt = OwningMerkleTree::<A, sha2::Sha256>::from_iter(
-        (0..max_size).map(A),
-    );
+    let mut bulkomt =
+        OwningMerkleTree::<A, sha2::Sha256>::from_iter((0..max_size).map(A));
     let mut bulksmt = SignedMerkleTree::<sha2::Sha256>::new(kp);
     let mut bulksomt = SignedOwningMerkleTree::<A, sha2::Sha256>::new(okp);
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -4,10 +4,13 @@
 extern crate rmp_serde;
 extern crate merkle_rs;
 extern crate serde;
+extern crate sha2;
+extern crate byteorder;
 
-
-use merkle_rs::KeyPair;
+use byteorder::{BigEndian, ByteOrder};
+use merkle_rs::{KeyPair, MerkleTree, digest};
 use serde::Serialize;
+
 
 
 #[test]
@@ -24,4 +27,34 @@ fn keypair_serde() {
         .unwrap();
     assert!(buf == buf2);
     assert!(kp.pub_key() == x.pub_key());
+}
+
+#[test]
+fn tree_serde() {
+    let mut mt = MerkleTree::<sha2::Sha256>::new();
+    let hash = <sha2::Sha256 as digest::Digest>::hash_elem(&A(1));
+    mt.insert(hash.clone());
+    let mut buf = Vec::new();
+    mt.serialize(&mut rmp_serde::Serializer::new(&mut buf))
+        .unwrap();
+    let buf2 = buf.clone();
+    let mut de = rmp_serde::Deserializer::new(&buf[..]);
+    let x: MerkleTree<sha2::Sha256> = serde::Deserialize::deserialize(&mut de)
+        .unwrap();
+    let mut buf = Vec::new();
+    x.serialize(&mut rmp_serde::Serializer::new(&mut buf))
+        .unwrap();
+    assert!(buf == buf2);
+    assert!(x.inclusion_proof(hash).is_some());
+}
+
+#[derive(Hash, Eq, PartialEq)]
+struct A(usize);
+
+impl digest::Digestible for A {
+    fn hash_bytes(&self, digest: &mut digest::Input) {
+        let mut b = [0; 8];
+        BigEndian::write_u64(&mut b, self.0 as u64);
+        digest.process(&b)
+    }
 }


### PR DESCRIPTION
Serde generates trait bounds which are too strict for our needs.